### PR TITLE
fix: report option argument to be optional + update help text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import {
   Context,
@@ -94,7 +95,11 @@ program
       'Enable verbose mode, providing detailed information about the operations'
     ).default(true)
   )
-  .addOption(new Option('-r, --report <filename>', 'Output report to file'))
+  .addOption(
+    new Option('-r, --report [filename]', 'Output report to file').preset(
+      path.join(os.homedir(), 'Desktop', 'cio-sdk-tools-output.logs')
+    )
+  )
   .action((path, options) => {
     configureLogger({
       verbose: options.verbose,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,4 @@
 import chalk from 'chalk';
-import * as os from 'os';
-import * as path from 'path';
 import winston from 'winston';
 
 const logger: winston.Logger = createLogger();
@@ -137,20 +135,9 @@ export function configureLogger(options: {
 }) {
   logger.level = options.verbose ? 'info' : 'warn';
   if (options.saveReport !== undefined) {
-    let destination: string;
-    if (options.saveReport === '') {
-      destination = path.join(
-        os.homedir(),
-        'Desktop',
-        'cio-sdk-tools-output.logs'
-      );
-    } else {
-      destination = options.saveReport;
-    }
-
     logger.add(
       new winston.transports.File({
-        filename: destination,
+        filename: options.saveReport,
         format: winston.format.combine(
           winston.format.timestamp(),
           fileFormat()


### PR DESCRIPTION
using `--report` option threw error as argument was required
```
❯  npm start doctor -- ../customerio-ios --report

error: option '-r, --report <filename>' argument missing
```

also moved where the default report path is set so that it shows up in the help text.

```
❯  npm start doctor -- -h

Usage: cio-sdk-tools doctor [options] [path]

Analyzes the project at the given path, performs diagnostics, and provides recommendations for improvements

Arguments:
  path                     Path to project directory (default: ".")

Options:
  -v, --verbose            Enable verbose mode, providing detailed information about the operations (default: true)
  -r, --report [filename]  Output report to file (preset: "/Users/jatinn/Desktop/cio-sdk-tools-output.logs")
  -h, --help               display help for command
```

