### PR TITLE
build: updates to make the cli tool executable for npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "main": "src/core/index",
   "scripts": {
     "doctor": "npm start doctor",
-    "build": "npx tsc",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "lint:fix": "npx eslint 'src/**/*.{js,ts}' --fix",
     "format": "npx prettier --write 'src/**/*.ts' && (npm run lint:fix || true)",
     "lint:report": "npm run lint -- --output-file eslint_report.json --format json",
     "start": "npx tsc && node dist/index.js",
     "compile": "npx tsc"
+  },
+  "bin": {
+    "cio-sdk-tools": "./dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Command, Option } from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';


### PR DESCRIPTION
had tried running the tool using `npx` from a different dir and got the following error:

```
❯  npx ../cio-sdk-tools doctor -h
npm ERR! could not determine executable to run
```