### PR TITLE
refactor: print the correct report path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ async function doctor(projectPathArg: string, options: DoctorCommandOptions) {
 
   logger.linebreak();
   if (options.report) {
-    const reportPath = getAbsolutePath(projectPath, options.report);
+    const reportPath = getAbsolutePath('.', options.report);
     logger.bold(`Diagnostic complete! File saved to: ${reportPath}`);
   } else {
     logger.bold(`Diagnostic complete!`);


### PR DESCRIPTION
if a report path was provided, then the location listed in the tool output was incorrect as for relative paths it used the project root as the base path.
so the report location and the output do not match

```
# pwd is cio-sdk-tools 
> npm start doctor -- ../amiapp-reactnative --report report.log
...
Diagnostic complete! File saved to: .../amiapp-reactnative/report.log
```
in the above example the report is said to live in the `amiapp-reactnative` dir however that is not the case it is actually under the `cio-sdk-tools` dir
