### PR TITLE
fix: update repo links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/customerio/sdk-self-service.git"
+    "url": "git+https://github.com/customerio/cio-sdk-tools.git"
   },
   "author": "CustomerIO Team",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/customerio/sdk-self-service/issues"
+    "url": "https://github.com/customerio/cio-sdk-tools/issues"
   },
-  "homepage": "https://github.com/customerio/sdk-self-service#readme",
+  "homepage": "https://github.com/customerio/cio-sdk-tools#readme",
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^11.0.0",


### PR DESCRIPTION
noticed npm page did not render the readme and saw that the package.json file had the old repo name in the links `sdk-self-service` updates them to `cio-sdk-tools`, maybe npm does not resolve the redirects.