### PR TITLE
feat: log version of tool & inform if newer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ The tool assists in diagnosing and troubleshooting the Customer.io mobile SDK in
 To run the diagnostic tool:
 
 ```bash
-npx cio-sdk-tools doctor
+npx cio-sdk-tools@latest doctor
 ```
 
 **Example**:
 
 Export Logs to Your Preferred Location:
 ```bash
-npx cio-sdk-tools doctor /path/to/project -r diagnostics_report.txt
+npx cio-sdk-tools doctor@latest /path/to/project --report diagnostics_report.txt
 ```
 View Additional Options:
 ```bash
-npx cio-sdk-tools doctor /path/to/project -h
+npx cio-sdk-tools@latest doctor /path/to/project --help
 ```
 
 ## Reporting Issues

--- a/src/checks/react_native.ts
+++ b/src/checks/react_native.ts
@@ -4,7 +4,7 @@ import { CheckGroup } from '../types';
 import {
   extractVersionFromPackageJson,
   extractVersionFromPackageLock,
-  fetchLatestVersion,
+  fetchCachedLatestVersion,
   logger,
   removeNonAlphanumericChars,
   runCatching,
@@ -114,7 +114,9 @@ async function validateSDKInitialization(
 }
 
 async function validateSDKVersion(project: ReactNativeProject): Promise<void> {
-  const latestSdkVersion = await fetchLatestVersion(PACKAGE_NAME_REACT_NATIVE);
+  const latestSdkVersion = await fetchCachedLatestVersion(
+    PACKAGE_NAME_REACT_NATIVE
+  );
 
   let packageFileSDKVersion: string | undefined;
   let parsedSDKVersion: string | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from './core';
 import { CheckGroup } from './types';
 import {
+  fetchLatestVersion,
   getAbsolutePath,
   isDirectoryNonEmpty,
   logger,
@@ -128,11 +129,27 @@ program
       path.join(os.homedir(), 'Desktop', 'cio-sdk-tools-output.logs')
     )
   )
-  .action((path: string, options: DoctorCommandOptions) => {
+  .action(async (path: string, options: DoctorCommandOptions) => {
     configureLogger({
       verbose: options.verbose,
       logFilePath: options.report,
     });
+
+    logger.debug(
+      `Running ${packageJson.name} on version ${packageJson.version}`
+    );
+
+    try {
+      const latestVersion = await fetchLatestVersion(packageJson.name);
+      if (latestVersion && latestVersion !== packageJson.version) {
+        logger.warning(
+          `Newer version of ${packageJson.name} available ${latestVersion}, currently on ${packageJson.version}`
+        );
+      }
+    } catch {
+      // catch block is empty because fetchLatestVersion will log the error
+    }
+
     doctor(path, options).catch((err) =>
       logger.error('Error running doctor:', err)
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from './core';
 import { CheckGroup } from './types';
 import {
-  fetchLatestVersion,
+  fetchCachedLatestVersion,
   getAbsolutePath,
   isDirectoryNonEmpty,
   logger,
@@ -140,7 +140,7 @@ program
     );
 
     try {
-      const latestVersion = await fetchLatestVersion(packageJson.name);
+      const latestVersion = await fetchCachedLatestVersion(packageJson.name);
       if (latestVersion && latestVersion !== packageJson.version) {
         logger.warning(
           `Newer version of ${packageJson.name} available ${latestVersion}, currently on ${packageJson.version}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,15 +139,11 @@ program
       `Running ${packageJson.name} on version ${packageJson.version}`
     );
 
-    try {
-      const latestVersion = await fetchCachedLatestVersion(packageJson.name);
-      if (latestVersion && latestVersion !== packageJson.version) {
-        logger.warning(
-          `Newer version of ${packageJson.name} available ${latestVersion}, currently on ${packageJson.version}`
-        );
-      }
-    } catch {
-      // catch block is empty because fetchLatestVersion will log the error
+    const latestVersion = await fetchCachedLatestVersion(packageJson.name);
+    if (latestVersion && latestVersion !== packageJson.version) {
+      logger.warning(
+        `Newer version of ${packageJson.name} available ${latestVersion}, currently on ${packageJson.version}`
+      );
     }
 
     doctor(path, options).catch((err) =>

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,46 @@
+import os from 'os';
+import path from 'path';
+import { env } from 'process';
+import { fetchLatestGitHubRelease } from './version';
+import { readFileWithStats } from './file';
+import * as logger from './logger';
+import { mkdir, writeFile } from 'fs/promises';
+
+export function getCacheDir(): string {
+  return path.join(
+    env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'),
+    'cio-sdk-tools'
+  );
+}
+
+// to avoid hitting GitHub api rate limits, we'll cache the latest version for an hour
+export async function fetchCachedLatestVersion(
+  packageName: string
+): Promise<string | undefined> {
+  const cacheDir = getCacheDir();
+  const cacheKey = `${packageName}.latest`;
+  const cachePath = path.join(cacheDir, cacheKey);
+
+  const results = readFileWithStats([cachePath]);
+  if (results) {
+    const r = results[0];
+    if (r.lastUpdated && r.lastUpdated >= Date.now() - 60 * 60 * 1000) {
+      return r.content;
+    }
+  }
+
+  try {
+    const latestVersion = await fetchLatestGitHubRelease(packageName);
+    if (!latestVersion) {
+      return undefined;
+    }
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(cachePath, latestVersion);
+    return latestVersion;
+  } catch (err) {
+    logger.debug(
+      `Unable to cache latest version for ${packageName}.  Error: ${err}`
+    );
+    return undefined;
+  }
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -24,7 +24,8 @@ export async function fetchCachedLatestVersion(
   const results = readFileWithStats([cachePath]);
   if (results) {
     const r = results[0];
-    if (r.lastUpdated && r.lastUpdated >= Date.now() - 60 * 60 * 1000) {
+    const cacheDurationMs = 60 * 60 * 1000;
+    if (r.lastUpdated && r.lastUpdated >= Date.now() - cacheDurationMs) {
       return r.content;
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * as logger from './logger';
 export * from './patterns';
 export * from './string';
 export * from './version';
+export * from './cache';


### PR DESCRIPTION
- adds a debug log of the current version of the tool being used
- adds a check to see if latest version of the tool is being used


output using the verbose flag
```
❯  npm start doctor -- ../amiapp-flutter -v

Running cio-sdk-tools on version 1.0.1
[!] Newer version of cio-sdk-tools available 1.0.2, currently on 1.0.1
...
```