### PR TITLE
fix: version check react native regex and format update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cio-sdk-tools",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cio-sdk-tools",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -46,7 +46,17 @@ export function extractVersionFromPackageLock(
     return lockVersionMatch ? lockVersionMatch[1] : undefined;
   } else if (packageLockType === 'npm') {
     const npmLockJson = JSON.parse(packageLockContent);
-    return npmLockJson.dependencies[packageName].version;
+    // Regex to match the package name
+    const packagePatternNpm: RegExp = new RegExp(`${packageName}`, 'i');
+
+    // Find a matching dependency
+    const matchingPackage = Object.keys(npmLockJson.packages).find((dep) =>
+      packagePatternNpm.test(dep)
+    );
+
+    return matchingPackage
+      ? npmLockJson.packages[matchingPackage].version
+      : undefined;
   } else {
     return undefined;
   }


### PR DESCRIPTION
The check was failing for `lock` files, which was referring to `node_modules` 

```
"node_modules/customerio-reactnative": {
      "version": "3.1.8",
      "resolved": "file:../../customerio-reactnative.tgz",
      "integrity": "sha512-61IPQL96LC2HLJOS7FgDqdpR46Pd0vh4Awf+xsZESptwFZekFpZU5+UKYYSW2CvUemTzRowWtsU16LAQRo6JDw==",
      "hasInstallScript": true,
      "license": "MIT",
      "peerDependencies": {
        "react": "*",
        "react-native": "*"
      }
    }
```