### PR TITLE
feat: add new send-push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,105 @@
 # cio-sdk-tools
 
+A collection of tools to assist in the integration of the Customer.io mobile SDKs.
+
 ## 🚧 This tool is a work in progress. 
-For feedback or feature requests, [open an issue](https://github.com/customerio/cio-sdk-tools/issues/new). The tool aims to diagnose common scenarios when integrating the Customer.io mobile SDK in your mobile app. Keep in mind that advanced or custom implementations might require manual troubleshooting.
+For feedback or feature requests, [open an issue](https://github.com/customerio/cio-sdk-tools/issues/new).
 
-The tool caters to React Native, Flutter, and iOS Native applications. If you're using a different framework, you can still use the tool to diagnose your iOS Native integration.
+## Available Commands
+<details>
+      <summary>doctor: Diagnose common scenarios when integrating the Customer.io mobile SDK</summary>
 
-The tool currently recognizes:
-- **Cocoapods**
+   > **Warning**
+   >
+   > The tool aims to diagnose common scenarios when integrating the Customer.io mobile SDK in your mobile app.
+   > Keep in mind that advanced or custom implementations might require manual troubleshooting.
+   >
+   > The tool caters to React Native, Flutter, and iOS Native applications. If you're using a different framework, you can still use the tool to diagnose your iOS Native integration.
+   >
+   > The tool currently recognizes:
+   > - **Cocoapods**
+   >
+   > (Note: Swift Package Manager (SPM) is not supported at this time.)
 
-(Note: Swift Package Manager (SPM) is not supported at this time.)
+   ## What It Does
+   The tool assists in diagnosing and troubleshooting the Customer.io mobile SDK installations. It examines:
+
+   1. **Project Setup**: Recognizing your mobile framework, such as React Native.
+   2. **SDK Initialization**: Verification of the SDK's initiation within key project files based on our setup guide recommendations.
+   3. **Push Notification Setup**:
+      - Validation of the presence and correct embedding of Notification Service Extensions.
+      - Verification of deployment target versions to ensure compatibility with the CIO SDK.
+      - Examination of `AppDelegate` to ensure correct metrics tracking for push notifications.
+      - Checking entitlements for push notification capabilities and potential conflicts.
+   4. **Dependencies**:
+      - Validation against any conflicting libraries in `package.json` and `Podfile` for now.
+      - Consolidates and displays versions of key integrations like the Customer.io SDK in various configuration files.
+
+   ### Learn More
+
+   | Section                 | iOS                                                                                   | React Native                                                                                   | Flutter                                                                                   |
+   |-------------------------|---------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+   | SDK Initialization      | [Read More](https://www.customer.io/docs/sdk/ios/getting-started/#initialize-the-sdk) | [Read More](https://www.customer.io/docs/sdk/react-native/getting-started/#initialize-the-sdk) | [Read More](https://www.customer.io/docs/sdk/flutter/getting-started/#initialize-the-sdk) |
+   | Push Notification Setup | [Read More](https://www.customer.io/docs/sdk/ios/push/#rich-push)                     | [Read More](https://www.customer.io/docs/sdk/react-native/push-notifications/push/)            | [Read More](https://www.customer.io/docs/sdk/flutter/push-notifications/push/)            |
 
 
-## What It Does
-The tool assists in diagnosing and troubleshooting the Customer.io mobile SDK installations. It examines:
+   ## Usage
 
-1. **Project Setup**: Recognizing your mobile framework, such as React Native.
-2. **SDK Initialization**: Verification of the SDK's initiation within key project files based on our setup guide recommendations.
-3. **Push Notification Setup**:
-    - Validation of the presence and correct embedding of Notification Service Extensions.
-    - Verification of deployment target versions to ensure compatibility with the CIO SDK.
-    - Examination of `AppDelegate` to ensure correct metrics tracking for push notifications.
-    - Checking entitlements for push notification capabilities and potential conflicts.
-4. **Dependencies**: 
-    - Validation against any conflicting libraries in `package.json` and `Podfile` for now.
-    - Consolidates and displays versions of key integrations like the Customer.io SDK in various configuration files.
+   ### Doctor Command
+   To run the diagnostic tool:
 
-### Learn More
+   ```bash
+   npx cio-sdk-tools@latest doctor
+   ```
 
-| Section                | iOS                             | React Native                       | Flutter                         |
-|------------------------|---------------------------------|------------------------------------|---------------------------------|
-| SDK Initialization     | [Read More](https://www.customer.io/docs/sdk/ios/getting-started/#initialize-the-sdk) | [Read More](https://www.customer.io/docs/sdk/react-native/getting-started/#initialize-the-sdk) | [Read More](https://www.customer.io/docs/sdk/flutter/getting-started/#initialize-the-sdk) |
-| Push Notification Setup| [Read More](https://www.customer.io/docs/sdk/ios/push/#rich-push) | [Read More](https://www.customer.io/docs/sdk/react-native/push-notifications/push/) | [Read More](https://www.customer.io/docs/sdk/flutter/push-notifications/push/) |
+   **Example**:
 
+   Export Logs to Your Preferred Location:
+   ```bash
+   npx cio-sdk-tools doctor@latest /path/to/project --report diagnostics_report.txt
+   ```
+   View Additional Options:
+   ```bash
+   npx cio-sdk-tools@latest doctor /path/to/project --help
+   ```
 
-## Usage
+</details>
 
-### Doctor Command
-To run the diagnostic tool:
+<details>
+   <summary>send-push: Send a rich push notification to a specified device</summary>
 
-```bash
-npx cio-sdk-tools@latest doctor
-```
+   ## What It Does
 
-**Example**:
+   The tool assists in sending a rich push notification to a specified device.
+   The rich notification contains an image to be able to test that the app is configured correctly to receive rich push notifications.
+   Optionally, you can also send a deep link to test that the app handles those correctly.
 
-Export Logs to Your Preferred Location:
-```bash
-npx cio-sdk-tools doctor@latest /path/to/project --report diagnostics_report.txt
-```
-View Additional Options:
-```bash
-npx cio-sdk-tools@latest doctor /path/to/project --help
-```
+   ## Usage
+
+   **Example**:
+
+   Using the native push provider for the related device platform:
+
+   ```bash
+   npx cio-sdk-tools@latest send-push --api-key API_KEY --token DEVICE_TOKEN --platform DEVICE_PLATFORM
+   ```
+
+   Specifying a deep link to be sent with the push notification:
+
+   ```bash
+   npx cio-sdk-tools@latest send-push --api-key API_KEY --token DEVICE_TOKEN --platform DEVICE_PLATFORM --deep-link DEEP_LINK
+   ```
+
+   > **Info**
+   >
+   > If you are using Firebase Cloud Messaging (FCM) on iOS as your push provider, you would need to use the `--provider` flag.
+
+   View Additional Options:
+   ```bash
+   npx cio-sdk-tools@latest send-push --help
+   ```
+
+</details>
 
 ## Reporting Issues
 Encounter problems or have suggestions? [Create an issue on GitHub](https://github.com/customerio/cio-sdk-tools/issues).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,14 @@ For feedback or feature requests, [open an issue](https://github.com/customerio/
    >
    > If you are using Firebase Cloud Messaging (FCM) on iOS as your push provider, you would need to use the `--provider` flag.
 
+   Specifying provider when using FCM with iOS app:
+
+   ```bash
+   npx cio-sdk-tools@latest send-push --api-key API_KEY --token DEVICE_TOKEN --platform ios --provider fcm
+   ```
+
    View Additional Options:
+
    ```bash
    npx cio-sdk-tools@latest send-push --help
    ```

--- a/README.md
+++ b/README.md
@@ -7,19 +7,7 @@ For feedback or feature requests, [open an issue](https://github.com/customerio/
 
 ## Available Commands
 <details>
-      <summary>doctor: Diagnose common scenarios when integrating the Customer.io mobile SDK</summary>
-
-   > **Warning**
-   >
-   > The tool aims to diagnose common scenarios when integrating the Customer.io mobile SDK in your mobile app.
-   > Keep in mind that advanced or custom implementations might require manual troubleshooting.
-   >
-   > The tool caters to React Native, Flutter, and iOS Native applications. If you're using a different framework, you can still use the tool to diagnose your iOS Native integration.
-   >
-   > The tool currently recognizes:
-   > - **Cocoapods**
-   >
-   > (Note: Swift Package Manager (SPM) is not supported at this time.)
+   <summary>doctor: Diagnose common scenarios when integrating the Customer.io mobile SDK</summary>
 
    ## What It Does
    The tool assists in diagnosing and troubleshooting the Customer.io mobile SDK installations. It examines:
@@ -34,6 +22,17 @@ For feedback or feature requests, [open an issue](https://github.com/customerio/
    4. **Dependencies**:
       - Validation against any conflicting libraries in `package.json` and `Podfile` for now.
       - Consolidates and displays versions of key integrations like the Customer.io SDK in various configuration files.
+
+   > **Warning**
+   >
+   > Advanced or custom implementations might require manual troubleshooting.
+   >
+   > The tool caters to React Native, Flutter, and iOS Native applications. If you're using a different framework, you can still use the tool to diagnose your iOS Native integration.
+   >
+   > The tool currently recognizes:
+   > - **Cocoapods**
+   >
+   > (Note: Swift Package Manager (SPM) is not supported at this time.)
 
    ### Learn More
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For feedback or feature requests, [open an issue](https://github.com/customerio/
    npx cio-sdk-tools@latest send-push --api-key API_KEY --token DEVICE_TOKEN --platform DEVICE_PLATFORM --deep-link DEEP_LINK
    ```
 
-   > **Info**
+   > **Important**
    >
    > If you are using Firebase Cloud Messaging (FCM) on iOS as your push provider, you would need to use the `--provider` flag.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { program } from 'commander';
 import { doctorCommand } from './doctor';
+import { sendPushCommand } from './send_push';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json');
@@ -12,5 +13,6 @@ program
   .description(packageJson.description);
 
 program.addCommand(doctorCommand);
+program.addCommand(sendPushCommand);
 
 program.parse();

--- a/src/send_push/index.ts
+++ b/src/send_push/index.ts
@@ -47,7 +47,7 @@ async function send(options: sendOptions) {
   const reqOpts: https.RequestOptions = {
     port: 443,
     hostname: 'api.customer.io',
-    path: '/experimental/verify/push',
+    path: '/v1/verify/push',
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/send_push/index.ts
+++ b/src/send_push/index.ts
@@ -15,10 +15,10 @@ export const sendPushCommand = new Command('send-push')
       .makeOptionMandatory()
   )
   .addOption(
-    new Option('--provider <provider>', 'Push provider').choices([
-      'apns',
-      'fcm',
-    ])
+    new Option(
+      '--provider <provider>',
+      'Push provider to use to deliver the notification'
+    ).choices(['apns', 'fcm'])
   )
   .option(
     '--deep-link <deepLink>',

--- a/src/send_push/index.ts
+++ b/src/send_push/index.ts
@@ -1,0 +1,90 @@
+import https from 'node:https';
+import { Command, Option } from 'commander';
+import { createLogger } from './logger';
+
+export const sendPushCommand = new Command('send-push')
+  .description('Send a rich push notification to a specified device.')
+  .requiredOption(
+    '--api-key <apiKey>',
+    'App API key for your customer.io workspace. You can visit https://fly.customer.io/settings/api_credentials?keyType=app to get your API key.'
+  )
+  .requiredOption('--token <token>', 'Device token to send push to')
+  .addOption(
+    new Option('--platform <platform>', 'Platform of the device')
+      .choices(['ios', 'android'])
+      .makeOptionMandatory()
+  )
+  .addOption(
+    new Option('--provider <provider>', 'Push provider').choices([
+      'apns',
+      'fcm',
+    ])
+  )
+  .option(
+    '--deep-link <deepLink>',
+    'Deep link to send in the test push notification'
+  )
+  .action(send);
+
+type sendOptions = {
+  apiKey: string;
+  token: string;
+  platform: string;
+  provider: string;
+  deepLink: string;
+};
+
+async function send(options: sendOptions) {
+  const logger = createLogger();
+
+  const data = JSON.stringify({
+    device_token: options.token,
+    device_platform: options.platform,
+    deep_link: options.deepLink,
+    push_provider: options.provider,
+  });
+
+  const reqOpts: https.RequestOptions = {
+    port: 443,
+    hostname: 'api.customer.io',
+    path: '/experimental/verify/push',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': data.length,
+      'Authorization': `Bearer ${options.apiKey}`,
+    },
+    timeout: 30_000, // 30 seconds
+  };
+
+  const req = https.request(reqOpts, (res) => {
+    let data = '';
+    res.on('data', (chunk) => (data += chunk));
+    res.on('end', () => {
+      const contentType = res.headers['content-type'];
+      if (!contentType || !contentType.includes('application/json')) {
+        logger.error(`something went wrong`, {
+          status: res.statusCode,
+          response: data,
+        });
+        process.exit(1);
+      }
+
+      const response = JSON.parse(data);
+      if (res.statusCode !== 200) {
+        logger.error(`could not send push`, { ...response });
+        process.exit(1);
+      }
+
+      logger.info('success', { ...response });
+    });
+  });
+
+  req.on('error', (err) => {
+    logger.error(`could not make request`, { error: err });
+    process.exit(1);
+  });
+
+  req.write(data);
+  req.end();
+}

--- a/src/send_push/logger.ts
+++ b/src/send_push/logger.ts
@@ -1,0 +1,19 @@
+import winston from 'winston';
+
+export function createLogger() {
+  return winston.createLogger({
+    level: 'info',
+    format: winston.format.errors({ stack: true }),
+    transports: [
+      new winston.transports.Console({
+        format: winston.format.combine(
+          winston.format.timestamp(),
+          winston.format(({ timestamp, level, message, ...args }) => {
+            return { timestamp, level, message, ...args };
+          })(),
+          winston.format.json({ deterministic: false })
+        ),
+      }),
+    ],
+  });
+}


### PR DESCRIPTION
add a command to easily send rich push notifications from customer.io to test that the app is configured correctly to receive and display rich push notifications