### PR TITLE
feat: support for automatic push handling on iOS

### DIFF
--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   Conflicts,
-  POD_DATA_PIPELINE,
   POD_MESSAGING_IN_APP,
   POD_MESSAGING_PUSH_APN,
   POD_MESSAGING_PUSH_FCM,
@@ -470,14 +469,7 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
     return podVersions !== undefined;
   };
 
-  if (project.framework == 'iOS') {
-    // Since iOS SDK 3.0.0, we have removed Tracking module and apps should use Data Pipeline module now
-    // Validate Data Pipeline module for native iOS apps
-    validatePod(POD_DATA_PIPELINE);
-  } else {
-    // For other frameworks, validate Tracking module since Data Pipeline is not currently supported by them
-    validatePod(POD_TRACKING);
-  }
+  validatePod(POD_TRACKING);
   validatePod(POD_MESSAGING_IN_APP);
 
   // Alert message for updating Push Messaging pods

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -7,7 +7,7 @@ import {
   POD_MESSAGING_PUSH_FCM,
   POD_TRACKING,
   iOS_DEPLOYMENT_TARGET_MIN_REQUIRED,
-  iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT,
+  iOS_SDK_PUSH_SWIZZLE_VERSION,
 } from '../constants';
 import { Context, iOSProject } from '../core';
 import { CheckGroup } from '../types';
@@ -453,7 +453,8 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
     if (podVersions) {
       logger.success(`${podName}: ${podVersions}`);
 
-      // Check if the pod version is lower than recommended for improved push notification tracking
+      // Check if the pod version is below the minimum required version
+      // If so, alert the user to update the pod for new features
       if (
         minRequiredVersion &&
         compareSemanticVersions(
@@ -474,7 +475,7 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
     // Validate Data Pipeline module for native iOS apps
     validatePod(POD_DATA_PIPELINE);
   } else {
-    // For other frameworks, validate Tracking module since Data Pipeline is not currently supported for them
+    // For other frameworks, validate Tracking module since Data Pipeline is not currently supported by them
     validatePod(POD_TRACKING);
   }
   validatePod(POD_MESSAGING_IN_APP);
@@ -485,13 +486,13 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
   const pushMessagingAPNPod = validatePod(
     POD_MESSAGING_PUSH_APN,
     true,
-    iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT,
+    iOS_SDK_PUSH_SWIZZLE_VERSION,
     pushMessagingPodUpdateMessage(POD_MESSAGING_PUSH_APN)
   );
   const pushMessagingFCMPod = validatePod(
     POD_MESSAGING_PUSH_FCM,
     true,
-    iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT,
+    iOS_SDK_PUSH_SWIZZLE_VERSION,
     pushMessagingPodUpdateMessage(POD_MESSAGING_PUSH_FCM)
   );
 

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -437,30 +437,10 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
   const podfileLock = project.podfileLock;
   const podfileLockContent = podfileLock.content;
 
-  const validatePod = (
-    podNameActual: string,
-    optional: boolean = false,
-    podNameAliases: string[] = []
-  ): boolean => {
-    let podName: string = podNameActual;
-
+  const validatePod = (podName: string, optional: boolean = false): boolean => {
     let podVersions: string | undefined;
     if (podfileLockContent) {
       podVersions = extractVersionFromPodLock(podfileLockContent, podName);
-
-      let index = 0;
-      while (!podVersions && index < podNameAliases.length) {
-        podVersions = extractVersionFromPodLock(
-          podfileLockContent,
-          podNameAliases[index]
-        );
-
-        if (podVersions) {
-          podName = podNameAliases[index];
-        }
-
-        index++;
-      }
     }
 
     if (podVersions) {
@@ -483,7 +463,11 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
     return podVersions !== undefined;
   };
 
-  validatePod(POD_TRACKING, false, [POD_DATA_PIPELINE]);
+  if (project.framework == 'iOS') {
+    validatePod(POD_DATA_PIPELINE);
+  } else {
+    validatePod(POD_TRACKING);
+  }
   validatePod(POD_MESSAGING_IN_APP);
 
   const pushMessagingAPNPod = validatePod(POD_MESSAGING_PUSH_APN, true);

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -6,10 +6,13 @@ import {
   POD_MESSAGING_PUSH_FCM,
   POD_TRACKING,
   iOS_DEPLOYMENT_TARGET_MIN_REQUIRED,
+  iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT,
 } from '../constants';
 import { Context, iOSProject } from '../core';
 import { CheckGroup } from '../types';
 import {
+  compareSemanticVersions,
+  extractSemanticVersion,
   extractVersionFromPodLock,
   getReadablePath,
   logger,
@@ -441,6 +444,18 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
 
     if (podVersions) {
       logger.success(`${podName}: ${podVersions}`);
+
+      // Check if the pod version is lower than recommended for improved push notification tracking
+      if (
+        compareSemanticVersions(
+          extractSemanticVersion(podVersions),
+          iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT
+        ) < 0
+      ) {
+        logger.alert(
+          `Please update ${podName} to latest version following the documentation for improved tracking of push notification metrics`
+        );
+      }
     } else if (!optional) {
       logger.failure(`${podName} module not found`);
     }

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -481,7 +481,7 @@ async function extractPodVersions(project: iOSProject): Promise<void> {
 
   // Alert message for updating Push Messaging pods
   const pushMessagingPodUpdateMessage = (podName: string) =>
-    `Please update ${podName} to latest version following the documentation for improved tracking of push notification metrics`;
+    `Please update ${podName} to latest version following our documentation for improved tracking of push notification metrics`;
   const pushMessagingAPNPod = validatePod(
     POD_MESSAGING_PUSH_APN,
     true,

--- a/src/doctor/constants/sdk.ts
+++ b/src/doctor/constants/sdk.ts
@@ -7,3 +7,6 @@ export const POD_MESSAGING_IN_APP = 'CustomerIOMessagingInApp';
 export const POD_MESSAGING_PUSH = 'CustomerIOMessagingPush';
 export const POD_MESSAGING_PUSH_APN = 'CustomerIOMessagingPushAPN';
 export const POD_MESSAGING_PUSH_FCM = 'CustomerIOMessagingPushFCM';
+
+// Specific versions of SDKs for which we have special handling in doctor tool
+export const iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT = '2.11';

--- a/src/doctor/constants/sdk.ts
+++ b/src/doctor/constants/sdk.ts
@@ -2,7 +2,6 @@ export const iOS_DEPLOYMENT_TARGET_MIN_REQUIRED = 13.0;
 export const GITHUB_ORG_NAME_CUSTOMER_IO = 'customerio';
 export const PACKAGE_NAME_REACT_NATIVE = 'customerio-reactnative';
 export const POD_COMMON = 'CustomerIOCommon';
-export const POD_DATA_PIPELINE = 'CustomerIODataPipelines';
 export const POD_TRACKING = 'CustomerIOTracking';
 export const POD_MESSAGING_IN_APP = 'CustomerIOMessagingInApp';
 export const POD_MESSAGING_PUSH = 'CustomerIOMessagingPush';

--- a/src/doctor/constants/sdk.ts
+++ b/src/doctor/constants/sdk.ts
@@ -2,6 +2,7 @@ export const iOS_DEPLOYMENT_TARGET_MIN_REQUIRED = 13.0;
 export const GITHUB_ORG_NAME_CUSTOMER_IO = 'customerio';
 export const PACKAGE_NAME_REACT_NATIVE = 'customerio-reactnative';
 export const POD_COMMON = 'CustomerIOCommon';
+export const POD_DATA_PIPELINE = 'CustomerIODataPipelines';
 export const POD_TRACKING = 'CustomerIOTracking';
 export const POD_MESSAGING_IN_APP = 'CustomerIOMessagingInApp';
 export const POD_MESSAGING_PUSH = 'CustomerIOMessagingPush';

--- a/src/doctor/constants/sdk.ts
+++ b/src/doctor/constants/sdk.ts
@@ -8,6 +8,8 @@ export const POD_MESSAGING_IN_APP = 'CustomerIOMessagingInApp';
 export const POD_MESSAGING_PUSH = 'CustomerIOMessagingPush';
 export const POD_MESSAGING_PUSH_APN = 'CustomerIOMessagingPushAPN';
 export const POD_MESSAGING_PUSH_FCM = 'CustomerIOMessagingPushFCM';
-
-// Specific versions of SDKs for which we have special handling in doctor tool
-export const iOS_SDK_WITH_PUSH_SWIZZLING_SUPPORT = '2.11';
+/**
+ * Specific versions of SDKs for which we have special handling in doctor tool
+ */
+// iOS SDK version that introduced support for swizzling in push module
+export const iOS_SDK_PUSH_SWIZZLE_VERSION = '2.11';

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -109,7 +109,7 @@ export function fetchLatestGitHubRelease(
 /**
  * Extracts the first semantic version number from a string that may contain multiple versions separated by commas.
  *
- * @param versions input containing multiple versions
+ * @param versions String containing multiple versions
  * @returns First semantic version found in the string, or undefined if no version is found or input is undefined.
  */
 export function extractSemanticVersion(
@@ -126,8 +126,8 @@ export function extractSemanticVersion(
 /**
  * Compares two semantic version strings.
  *
- * @param version1 The first version string to compare.
- * @param version2 The second version string to compare.
+ * @param version1 First version string to compare.
+ * @param version2 Second version string to compare.
  * @returns -1 if version1 is less than version2, 1 if version1 is greater than version2, and 0 if they are equal.
  */
 export function compareSemanticVersions(

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -105,3 +105,52 @@ export function fetchLatestGitHubRelease(
     request.on('error', (error) => reject(error));
   });
 }
+
+/**
+ * Extracts the first semantic version number from a string that may contain multiple versions separated by commas.
+ *
+ * @param versions input containing multiple versions
+ * @returns First semantic version found in the string, or undefined if no version is found or input is undefined.
+ */
+export function extractSemanticVersion(
+  versions: string | undefined
+): string | undefined {
+  if (versions === undefined) return undefined;
+
+  // Regex pattern to match a semantic version number
+  const versionPattern = /\b\d+\.\d+(\.\d+)?\b/;
+  const match = versions.match(versionPattern);
+  return match ? match[0] : undefined;
+}
+
+/**
+ * Compares two semantic version strings.
+ *
+ * @param version1 The first version string to compare.
+ * @param version2 The second version string to compare.
+ * @returns -1 if version1 is less than version2, 1 if version1 is greater than version2, and 0 if they are equal.
+ */
+export function compareSemanticVersions(
+  version1: string | undefined,
+  version2: string | undefined
+): number {
+  // Handle undefined values
+  if (version1 === undefined && version2 === undefined) return 0;
+  if (version1 === undefined) return -1;
+  if (version2 === undefined) return 1;
+
+  const v1Parts = version1.split('.').map(Number);
+  const v2Parts = version2.split('.').map(Number);
+
+  // Compare each part of the version numbers
+  for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+    const part1 = v1Parts[i] ?? 0; // Use 0 for missing parts
+    const part2 = v2Parts[i] ?? 0; // Use 0 for missing parts
+
+    if (part1 > part2) return 1;
+    if (part1 < part2) return -1;
+  }
+
+  // If all parts are equal, return 0
+  return 0;
+}


### PR DESCRIPTION
Part of: [MBL-100](https://linear.app/customerio/issue/MBL-100/update-self-service-tool-after-automatic-push-handling-feature-launch)

### Changes

- Removed checks for validating `userNotificationCenter` function
- Added check to validate if `MessagingPush` module is initialized
- Added warning to update SDK if app is using any version older than `2.11`
- Helper methods to extract and compare semantic versions