### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Deploy git tag via semantic release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d # v3.4.2
         id: semantic-release
         with:
           # version numbers below can be in many forms: M, M.m, M.m.p

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       pull-requests: write # to comment on PRs
     steps:    
-    - uses: levibostian/action-conventional-pr-linter@v4
+    - uses: levibostian/action-conventional-pr-linter@acd7e6035a4c70ae2e6aab469c791cc5ca2a989d # v4.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - run: npm run lint:report
 
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v2
+        uses: ataylorme/eslint-annotate-action@5f4dc2e3af8d3c21b727edb597e5503510b1dc9c # v2
         with:
           check-name: 'eslint results'
           only-pr-files: false 


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version) Pins GitHub Actions as part of DX-516.