### PR TITLE
feat: add doctor support for android

### DIFF
--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -11,6 +11,7 @@ import { AndroidProject, Context } from '../core';
 import { CheckGroup } from '../types';
 import {
   compareSemanticVersions,
+  extractSemanticVersion,
   extractVersionFromBuildGradle,
   fetchCachedLatestVersion,
   logger,
@@ -276,7 +277,9 @@ async function validateDependencies(project: AndroidProject): Promise<void> {
     return;
   }
 
-  const latestSdkVersion = await fetchCachedLatestVersion('customerio-android');
+  const latestSdkVersion = extractSemanticVersion(
+    await fetchCachedLatestVersion('customerio-android')
+  );
 
   const modules = [
     { name: ANDROID_MODULE_DATA_PIPELINES, displayName: 'Data Pipelines' },

--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -1,0 +1,328 @@
+import {
+  ANDROID_MIN_SDK_VERSION,
+  ANDROID_MODULE_DATA_PIPELINES,
+  ANDROID_MODULE_MESSAGING_IN_APP,
+  ANDROID_MODULE_MESSAGING_PUSH_FCM,
+  ANDROID_PACKAGE_GROUP,
+  ANDROID_SDK_MIN_VERSION,
+} from '../constants';
+import { androidGradleDependencies } from '../constants/conflicts';
+import { AndroidProject, Context } from '../core';
+import { CheckGroup } from '../types';
+import {
+  compareSemanticVersions,
+  extractVersionFromBuildGradle,
+  fetchCachedLatestVersion,
+  logger,
+  runCatching,
+  searchFilesForCode,
+} from '../utils';
+import { doesExists } from '../utils/file';
+
+// Common search configurations for Android files
+const ANDROID_SOURCE_BASE_CONFIG = {
+  ignoreDirectories: ['build', '.gradle', 'gradle'],
+  targetFileNames: ['Application', 'App', 'MainActivity'],
+};
+
+const SDK_INIT_SEARCH_CONFIG = {
+  ...ANDROID_SOURCE_BASE_CONFIG,
+  targetFilePatterns: ['customerio', 'cio', 'initialize'],
+};
+
+const PUSH_SETUP_SEARCH_CONFIG = {
+  ...ANDROID_SOURCE_BASE_CONFIG,
+  targetFilePatterns: ['messaging', 'firebase', 'fcm', 'push'],
+};
+
+export async function runChecks(group: CheckGroup): Promise<void> {
+  const context = Context.get();
+  const project = context.project as AndroidProject;
+
+  switch (group) {
+    case CheckGroup.Diagnostics:
+      await runCatching(validateAndroidSdkVersions)(project);
+      break;
+
+    case CheckGroup.Initialization:
+      await runCatching(validateSDKInitialization)(project);
+      break;
+
+    case CheckGroup.PushSetup:
+      await runCatching(validateGoogleServices)(project);
+      await runCatching(validateFirebaseMessagingService)(project);
+      break;
+
+    case CheckGroup.Dependencies:
+      await runCatching(validateNoConflictingSDKs)(project);
+      await runCatching(validateDependencies)(project);
+      break;
+  }
+}
+
+/**
+ * Validates Android SDK versions (minSdkVersion, targetSdkVersion)
+ */
+async function validateAndroidSdkVersions(
+  project: AndroidProject
+): Promise<void> {
+  if (!project.appBuildGradle?.content) {
+    logger.warning('Unable to find app-level build.gradle file');
+    return;
+  }
+
+  // Try app build.gradle first
+  // Match both Groovy DSL (minSdk 21) and Kotlin DSL (minSdk = 24)
+  let minSdkMatch = project.appBuildGradle.content.match(
+    /minSdk(?:Version)?\s*[=:]?\s*(\d+)/
+  );
+  let targetSdkMatch = project.appBuildGradle.content.match(
+    /targetSdk(?:Version)?\s*[=:]?\s*(\d+)/
+  );
+
+  // If not found (variable references like rootProject.ext.minSdkVersion),
+  // try root build.gradle for wrapper frameworks
+  if ((!minSdkMatch || !targetSdkMatch) && project.rootBuildGradle?.content) {
+    if (!minSdkMatch) {
+      minSdkMatch = project.rootBuildGradle.content.match(
+        /minSdk(?:Version)?\s*[=:]?\s*(\d+)/
+      );
+    }
+    if (!targetSdkMatch) {
+      targetSdkMatch = project.rootBuildGradle.content.match(
+        /targetSdk(?:Version)?\s*[=:]?\s*(\d+)/
+      );
+    }
+  }
+
+  if (minSdkMatch) {
+    const minSdk = parseInt(minSdkMatch[1], 10);
+    if (minSdk < ANDROID_MIN_SDK_VERSION) {
+      logger.failure(
+        `minSdkVersion ${minSdk} is below required minimum ${ANDROID_MIN_SDK_VERSION}`
+      );
+    } else {
+      logger.success(`minSdkVersion: ${minSdk}`);
+    }
+  }
+
+  if (targetSdkMatch) {
+    const targetSdk = parseInt(targetSdkMatch[1], 10);
+    logger.success(`targetSdkVersion: ${targetSdk}`);
+  }
+}
+
+/**
+ * Validates CustomerIO SDK initialization in Application or MainActivity
+ *
+ * NOTE: For wrapper frameworks (React Native/Flutter), initialization happens
+ * in JavaScript/Dart code, not in native Android code. This check is skipped
+ * for wrapper frameworks.
+ */
+async function validateSDKInitialization(
+  project: AndroidProject
+): Promise<void> {
+  // Skip this check for wrapper frameworks - they initialize in JS/Dart
+  if (project.isWrapperFramework) {
+    logger.debug(
+      'Skipping native Android initialization check for wrapper framework'
+    );
+    return;
+  }
+
+  const initPattern = /CustomerIO\.initialize/;
+
+  const searchResults = searchFilesForCode(
+    {
+      codePatternByExtension: {
+        '.java': initPattern,
+        '.kt': initPattern,
+      },
+      ...SDK_INIT_SEARCH_CONFIG,
+    },
+    project.androidProjectPath
+  );
+
+  if (searchResults.matchedFiles.length > 0) {
+    logger.success('Found CustomerIO.initialize() in project');
+  } else {
+    logger.failure('Could not find CustomerIO.initialize() call');
+    logger.alert(
+      'Make sure to initialize the SDK in your Application class or MainActivity'
+    );
+  }
+}
+
+/**
+ * Validates Google Services configuration
+ */
+async function validateGoogleServices(project: AndroidProject): Promise<void> {
+  // Check for google-services.json
+  if (
+    project.googleServicesJson &&
+    doesExists(project.googleServicesJson.absolutePath)
+  ) {
+    logger.success('google-services.json file found');
+  } else {
+    logger.warning('google-services.json file not found');
+    logger.alert('Push notifications require Firebase configuration');
+  }
+
+  // Check for Google Services plugin in build.gradle
+  if (project.appBuildGradle?.content) {
+    const hasPlugin =
+      /apply\s+plugin:\s*['"]com\.google\.gms\.google-services['"]/.test(
+        project.appBuildGradle.content
+      ) ||
+      /id\s*\(?['"]com\.google\.gms\.google-services['"]/.test(
+        project.appBuildGradle.content
+      );
+
+    if (hasPlugin) {
+      logger.success('Google Services plugin applied');
+    } else {
+      logger.warning('Google Services plugin not found in app/build.gradle');
+    }
+  } else {
+    logger.debug(
+      'Unable to check Google Services plugin - build.gradle not loaded'
+    );
+  }
+}
+
+/**
+ * Validates FirebaseMessagingService implementation
+ *
+ * NOTE: A custom FirebaseMessagingService is NOT required.
+ * The Customer.io SDK automatically adds a FirebaseMessagingService to the manifest.
+ * Custom implementations are only needed if the app has specific push handling requirements.
+ */
+async function validateFirebaseMessagingService(
+  project: AndroidProject
+): Promise<void> {
+  // Look for custom FirebaseMessagingService extension
+  const servicePattern =
+    /:\s*FirebaseMessagingService\(\)|extends\s+FirebaseMessagingService/;
+
+  const searchResults = searchFilesForCode(
+    {
+      codePatternByExtension: {
+        '.java': servicePattern,
+        '.kt': servicePattern,
+      },
+      ...PUSH_SETUP_SEARCH_CONFIG,
+    },
+    project.androidProjectPath
+  );
+
+  if (searchResults.matchedFiles.length > 0) {
+    logger.success('Found custom FirebaseMessagingService implementation');
+    logger.debug(
+      'Custom implementation found - ensure it calls CustomerIOFirebaseMessagingService methods'
+    );
+  } else {
+    logger.success('Using SDK default FirebaseMessagingService');
+  }
+
+  // Check if service is registered in AndroidManifest.xml
+  if (project.androidManifest?.content) {
+    if (project.androidManifest.content.includes('FirebaseMessagingService')) {
+      logger.debug(
+        'FirebaseMessagingService registered in AndroidManifest.xml'
+      );
+    }
+  }
+}
+
+/**
+ * Validates no conflicting Android SDKs are present
+ */
+async function validateNoConflictingSDKs(
+  project: AndroidProject
+): Promise<void> {
+  if (!project.appBuildGradle?.content) return;
+
+  const conflictsFound: string[] = [];
+
+  for (const conflictingDep of androidGradleDependencies) {
+    if (project.appBuildGradle.content.includes(conflictingDep)) {
+      conflictsFound.push(conflictingDep);
+    }
+  }
+
+  if (conflictsFound.length > 0) {
+    logger.failure('Found conflicting Android push notification libraries:');
+    conflictsFound.forEach((dep) => logger.alert(`  - ${dep}`));
+  } else {
+    // Only show success for native Android projects
+    // For wrappers, this is redundant since iOS checks already covered it
+    if (!project.isWrapperFramework) {
+      logger.success('No conflicting Android push libraries detected');
+    }
+  }
+}
+
+/**
+ * Validates Customer.io SDK dependencies and versions
+ *
+ * NOTE: This check is primarily for native Android projects.
+ * React Native and Flutter projects include Android dependencies transitively
+ * through their wrapper SDKs (package.json/pubspec.yaml), so they won't have
+ * explicit io.customer.android:* dependencies in build.gradle.
+ */
+async function validateDependencies(project: AndroidProject): Promise<void> {
+  if (!project.appBuildGradle?.content) {
+    logger.warning('Unable to analyze dependencies - build.gradle not found');
+    return;
+  }
+
+  const latestSdkVersion = await fetchCachedLatestVersion('customerio-android');
+
+  const modules = [
+    { name: ANDROID_MODULE_DATA_PIPELINES, displayName: 'Data Pipelines' },
+    { name: ANDROID_MODULE_MESSAGING_IN_APP, displayName: 'Messaging In-App' },
+    {
+      name: ANDROID_MODULE_MESSAGING_PUSH_FCM,
+      displayName: 'Messaging Push FCM',
+    },
+  ];
+
+  let foundAny = false;
+
+  for (const module of modules) {
+    const version = extractVersionFromBuildGradle(
+      project.appBuildGradle.content,
+      ANDROID_PACKAGE_GROUP,
+      module.name
+    );
+
+    if (version) {
+      foundAny = true;
+      const sdkVersionMessage = `${module.displayName}: ${version}`;
+
+      if (compareSemanticVersions(version, ANDROID_SDK_MIN_VERSION) < 0) {
+        logger.warning(sdkVersionMessage);
+        logger.alert(
+          `Version ${version} is below recommended minimum ${ANDROID_SDK_MIN_VERSION}`
+        );
+      } else if (
+        latestSdkVersion &&
+        compareSemanticVersions(version, latestSdkVersion) < 0
+      ) {
+        logger.warning(sdkVersionMessage);
+        logger.alert(`Update to the latest SDK version ${latestSdkVersion}`);
+      } else {
+        logger.success(sdkVersionMessage);
+      }
+    }
+  }
+
+  if (!foundAny) {
+    // For native Android, this is a warning
+    // For React Native/Flutter, this is expected (dependencies come from wrapper SDK)
+    logger.debug(
+      'No explicit io.customer.android:* dependencies in build.gradle'
+    );
+    logger.debug('This is expected for React Native/Flutter projects');
+  }
+}

--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   ANDROID_MIN_SDK_VERSION,
   ANDROID_MODULE_DATA_PIPELINES,
@@ -18,7 +19,7 @@ import {
   runCatching,
   searchFilesForCode,
 } from '../utils';
-import { doesExists } from '../utils/file';
+import { doesExists, readDirectory, readFileContent } from '../utils/file';
 
 // Common search configurations for Android files
 const ANDROID_SOURCE_BASE_CONFIG = {
@@ -100,16 +101,16 @@ async function validateAndroidSdkVersions(
     const minSdk = parseInt(minSdkMatch[1], 10);
     if (minSdk < ANDROID_MIN_SDK_VERSION) {
       logger.failure(
-        `minSdkVersion ${minSdk} is below required minimum ${ANDROID_MIN_SDK_VERSION}`
+        `Min SDK Version ${minSdk} is below required minimum ${ANDROID_MIN_SDK_VERSION}`
       );
     } else {
-      logger.success(`minSdkVersion: ${minSdk}`);
+      logger.success(`Min SDK Version: ${minSdk}`);
     }
   }
 
   if (targetSdkMatch) {
     const targetSdk = parseInt(targetSdkMatch[1], 10);
-    logger.success(`targetSdkVersion: ${targetSdk}`);
+    logger.success(`Target SDK Version: ${targetSdk}`);
   }
 }
 
@@ -295,11 +296,30 @@ async function validateDependencies(project: AndroidProject): Promise<void> {
     },
   ];
 
+  // Collect all gradle file contents to search through
+  // Dependencies may be defined in separate .gradle files (e.g. via apply from:)
+  const gradleContents = [project.appBuildGradle.content];
+  const appDir = path.dirname(project.appBuildGradle.absolutePath);
+  const appFiles = readDirectory(appDir);
+  if (appFiles) {
+    for (const file of appFiles) {
+      if (
+        (file.endsWith('.gradle') || file.endsWith('.gradle.kts')) &&
+        file !== path.basename(project.appBuildGradle.absolutePath)
+      ) {
+        const content = readFileContent(path.join(appDir, file));
+        if (content) gradleContents.push(content);
+      }
+    }
+  }
+
+  const allGradleContent = gradleContents.join('\n');
+
   let foundAny = false;
 
   for (const module of modules) {
     const version = extractVersionFromBuildGradle(
-      project.appBuildGradle.content,
+      allGradleContent,
       ANDROID_PACKAGE_GROUP,
       module.name
     );

--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -252,8 +252,13 @@ async function validateNoConflictingSDKs(
   }
 
   if (conflictsFound.length > 0) {
-    logger.failure('Found conflicting Android push notification libraries:');
+    logger.warning(
+      'Potential conflicting Android push notification libraries:'
+    );
     conflictsFound.forEach((dep) => logger.alert(`  - ${dep}`));
+    logger.alert(
+      `Learn more at: ${project.documentation.multiplePushProviders}`
+    );
   } else {
     // Only show success for native Android projects
     // For wrappers, this is redundant since iOS checks already covered it
@@ -321,11 +326,12 @@ async function validateDependencies(project: AndroidProject): Promise<void> {
   }
 
   if (!foundAny) {
-    // For native Android, this is a warning
-    // For React Native/Flutter, this is expected (dependencies come from wrapper SDK)
-    logger.debug(
-      'No explicit io.customer.android:* dependencies in build.gradle'
-    );
-    logger.debug('This is expected for React Native/Flutter projects');
+    if (project.isWrapperFramework) {
+      logger.debug(
+        'No explicit io.customer.android:* dependencies in build.gradle'
+      );
+    } else {
+      logger.warning('No Customer.io SDK dependencies found in build.gradle');
+    }
   }
 }

--- a/src/doctor/checks/android.ts
+++ b/src/doctor/checks/android.ts
@@ -37,6 +37,30 @@ const PUSH_SETUP_SEARCH_CONFIG = {
   targetFilePatterns: ['messaging', 'firebase', 'fcm', 'push'],
 };
 
+/**
+ * Collects content from all gradle files in the app directory.
+ * Handles dependencies defined in separate .gradle files (e.g. via apply from:).
+ */
+function collectAllGradleContent(project: AndroidProject): string {
+  if (!project.appBuildGradle?.content) return '';
+
+  const gradleContents = [project.appBuildGradle.content];
+  const appDir = path.dirname(project.appBuildGradle.absolutePath);
+  const appFiles = readDirectory(appDir);
+  if (appFiles) {
+    for (const file of appFiles) {
+      if (
+        (file.endsWith('.gradle') || file.endsWith('.gradle.kts')) &&
+        file !== path.basename(project.appBuildGradle.absolutePath)
+      ) {
+        const content = readFileContent(path.join(appDir, file));
+        if (content) gradleContents.push(content);
+      }
+    }
+  }
+  return gradleContents.join('\n');
+}
+
 export async function runChecks(group: CheckGroup): Promise<void> {
   const context = Context.get();
   const project = context.project as AndroidProject;
@@ -244,10 +268,11 @@ async function validateNoConflictingSDKs(
 ): Promise<void> {
   if (!project.appBuildGradle?.content) return;
 
+  const allGradleContent = collectAllGradleContent(project);
   const conflictsFound: string[] = [];
 
   for (const conflictingDep of androidGradleDependencies) {
-    if (project.appBuildGradle.content.includes(conflictingDep)) {
+    if (allGradleContent.includes(conflictingDep)) {
       conflictsFound.push(conflictingDep);
     }
   }
@@ -296,24 +321,7 @@ async function validateDependencies(project: AndroidProject): Promise<void> {
     },
   ];
 
-  // Collect all gradle file contents to search through
-  // Dependencies may be defined in separate .gradle files (e.g. via apply from:)
-  const gradleContents = [project.appBuildGradle.content];
-  const appDir = path.dirname(project.appBuildGradle.absolutePath);
-  const appFiles = readDirectory(appDir);
-  if (appFiles) {
-    for (const file of appFiles) {
-      if (
-        (file.endsWith('.gradle') || file.endsWith('.gradle.kts')) &&
-        file !== path.basename(project.appBuildGradle.absolutePath)
-      ) {
-        const content = readFileContent(path.join(appDir, file));
-        if (content) gradleContents.push(content);
-      }
-    }
-  }
-
-  const allGradleContent = gradleContents.join('\n');
+  const allGradleContent = collectAllGradleContent(project);
 
   let foundAny = false;
 

--- a/src/doctor/checks/index.ts
+++ b/src/doctor/checks/index.ts
@@ -1,2 +1,3 @@
-export { runChecks as runChecksForIOS } from './ios';
-export { runChecks as runChecksForReactNative } from './react_native';
+export { runChecks as runChecksForAndroid } from './android.js';
+export { runChecks as runChecksForIOS } from './ios.js';
+export { runChecks as runChecksForReactNative } from './react_native.js';

--- a/src/doctor/constants/conflicts.ts
+++ b/src/doctor/constants/conflicts.ts
@@ -8,3 +8,8 @@ export const iosPods = ['OneSignal', 'Firebase/Messaging'];
 // packages, not individual products, so we cannot detect which specific products
 // are in use (e.g., firebase-ios-sdk includes Analytics, Auth, Messaging, etc).
 export const iosSPMPackages = ['onesignal-ios-sdk', 'firebase-ios-sdk'];
+
+export const androidGradleDependencies = [
+  'com.onesignal:OneSignal',
+  'com.google.firebase:firebase-messaging',
+];

--- a/src/doctor/constants/links.ts
+++ b/src/doctor/constants/links.ts
@@ -6,6 +6,11 @@ export const iOSDocumentation: Documentation = {
   multiplePushProviders: 'https://www.customer.io/docs/sdk/ios/push/#rich-push',
 };
 
+export const AndroidDocumentation: Documentation = {
+  multiplePushProviders:
+    'https://www.customer.io/docs/sdk/android/push/multiple-push-providers/',
+};
+
 export const ReactNativeDocumentation: Documentation = {
   multiplePushProviders:
     'https://www.customer.io/docs/sdk/react-native/push-notifications/multiple-push-providers/',

--- a/src/doctor/constants/sdk.ts
+++ b/src/doctor/constants/sdk.ts
@@ -22,3 +22,11 @@ export const SPM_MESSAGING_PUSH_FCM = 'MessagingPushFCM';
  */
 // iOS SDK version that introduced support for swizzling in push module
 export const iOS_SDK_PUSH_SWIZZLE_VERSION = '2.11';
+
+// Android SDK constants
+export const ANDROID_MIN_SDK_VERSION = 21;
+export const ANDROID_SDK_MIN_VERSION = '3.0.0';
+export const ANDROID_PACKAGE_GROUP = 'io.customer.android';
+export const ANDROID_MODULE_DATA_PIPELINES = 'datapipelines';
+export const ANDROID_MODULE_MESSAGING_IN_APP = 'messaging-in-app';
+export const ANDROID_MODULE_MESSAGING_PUSH_FCM = 'messaging-push-fcm';

--- a/src/doctor/core/index.ts
+++ b/src/doctor/core/index.ts
@@ -1,5 +1,7 @@
 export { Context } from './context';
 export {
+  AndroidNativeProject,
+  AndroidProject,
   FlutterProject,
   MobileProject,
   ReactNativeProject,

--- a/src/doctor/core/projects.ts
+++ b/src/doctor/core/projects.ts
@@ -79,6 +79,15 @@ export interface iOSProject extends MobileProject {
   appDelegateFiles: File[];
 }
 
+export interface AndroidProject extends MobileProject {
+  readonly androidProjectPath: string;
+  appBuildGradle: File;
+  rootBuildGradle: File;
+  googleServicesJson: File;
+  androidManifest: File;
+  isWrapperFramework: boolean;
+}
+
 // Use mixins to reuse code between classes
 const iOSProjectBase = <TBase extends Constructor>(Base: TBase) =>
   class extends Base {
@@ -260,6 +269,134 @@ const iOSProjectBase = <TBase extends Constructor>(Base: TBase) =>
     }
   };
 
+// Android mixin for code reuse between Android projects
+const AndroidProjectBase = <TBase extends Constructor>(Base: TBase) =>
+  class extends Base {
+    public projectPath!: string;
+    public androidProjectPath!: string;
+    public appBuildGradle!: File;
+    public rootBuildGradle!: File;
+    public googleServicesJson!: File;
+    public androidManifest!: File;
+    public isWrapperFramework: boolean = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(...args: any[]) {
+      super(...args);
+    }
+
+    // Must be called from constructor only
+    initAndroidProject() {
+      // Determine app build.gradle path
+      // Two possible structures:
+      // 1. Multi-module: android/app/build.gradle (wrapper frameworks) or app/build.gradle (native)
+      // 2. Single-module: build.gradle at root (sample apps)
+
+      const appBuildPaths = [
+        path.join(this.androidProjectPath, 'app', 'build.gradle'),
+        path.join(this.androidProjectPath, 'app', 'build.gradle.kts'),
+      ];
+
+      const rootBuildPaths = [
+        path.join(this.androidProjectPath, 'build.gradle'),
+        path.join(this.androidProjectPath, 'build.gradle.kts'),
+      ];
+
+      // Find app build.gradle (Groovy or Kotlin DSL)
+      let appBuildPath = appBuildPaths[0]; // default
+      let isSingleModule = false;
+
+      for (const buildPath of appBuildPaths) {
+        if (doesExists(buildPath)) {
+          appBuildPath = buildPath;
+          break;
+        }
+      }
+
+      // If app/build.gradle doesn't exist, check if root build.gradle is the app module
+      if (!doesExists(appBuildPath)) {
+        for (const buildPath of rootBuildPaths) {
+          if (doesExists(buildPath)) {
+            const content = fs.readFileSync(buildPath, 'utf8');
+            if (content.includes('com.android.application')) {
+              appBuildPath = buildPath;
+              isSingleModule = true;
+              break;
+            }
+          }
+        }
+      }
+
+      // Find root build.gradle (Groovy or Kotlin DSL)
+      let rootBuildPath = rootBuildPaths[0]; // default
+      for (const buildPath of rootBuildPaths) {
+        if (doesExists(buildPath)) {
+          rootBuildPath = buildPath;
+          break;
+        }
+      }
+
+      this.appBuildGradle = new File(this.projectPath, appBuildPath);
+      this.rootBuildGradle = new File(this.projectPath, rootBuildPath);
+
+      // For single-module projects, files are at root level
+      // For multi-module projects, files are in app/ subdirectory
+      const appSubdir = isSingleModule ? '' : 'app';
+
+      this.googleServicesJson = new File(
+        this.projectPath,
+        path.join(this.androidProjectPath, appSubdir, 'google-services.json')
+      );
+      this.androidManifest = new File(
+        this.projectPath,
+        path.join(
+          this.androidProjectPath,
+          appSubdir,
+          'src',
+          'main',
+          'AndroidManifest.xml'
+        )
+      );
+    }
+
+    async loadAndroidFilesContent(): Promise<void> {
+      this.appBuildGradle.loadContent();
+      this.rootBuildGradle.loadContent();
+      this.googleServicesJson.loadContent();
+      this.androidManifest.loadContent();
+    }
+
+    async runAndroidChecks(group: CheckGroup): Promise<void> {
+      const { runChecks } = await import('../checks/android.js');
+      await runChecks(group);
+    }
+  };
+
+export class AndroidNativeProject
+  extends AndroidProjectBase(Object)
+  implements MobileProject, AndroidProject
+{
+  public readonly framework: string = 'Android';
+  public readonly documentation: Links.Documentation =
+    Links.AndroidDocumentation;
+
+  constructor(projectPath: string) {
+    super();
+    this.projectPath = projectPath;
+    this.androidProjectPath = projectPath;
+    this.isWrapperFramework = false;
+    this.initAndroidProject();
+  }
+
+  async loadFilesContent(): Promise<void> {
+    await this.loadAndroidFilesContent();
+  }
+
+  async runChecks(group: CheckGroup): Promise<void> {
+    await this.runAndroidChecks(group);
+  }
+}
+
 export class iOSNativeProject
   extends iOSProjectBase(Object)
   implements MobileProject, iOSProject
@@ -285,8 +422,8 @@ export class iOSNativeProject
 }
 
 export class ReactNativeProject
-  extends iOSProjectBase(Object)
-  implements MobileProject, iOSProject
+  extends iOSProjectBase(AndroidProjectBase(Object))
+  implements MobileProject, iOSProject, AndroidProject
 {
   public readonly framework: string = 'React Native';
   public readonly documentation: Links.Documentation =
@@ -294,6 +431,7 @@ export class ReactNativeProject
 
   public readonly packageJsonFile: File;
   public packageLockFile?: File;
+  public isWrapperFramework: boolean = true;
 
   constructor(projectPath: string) {
     super();
@@ -301,6 +439,14 @@ export class ReactNativeProject
     this.iOSProjectPath = path.join(projectPath, 'ios');
 
     this.initIOSProject();
+
+    // Check if android directory exists
+    const androidPath = path.join(projectPath, 'android');
+    if (doesExists(androidPath)) {
+      this.androidProjectPath = androidPath;
+      this.initAndroidProject();
+    }
+
     this.packageJsonFile = new File(projectPath, 'package.json');
   }
 
@@ -312,6 +458,11 @@ export class ReactNativeProject
     this.podfile.loadContent();
     this.podfileLock.loadContent();
     this.packageResolved.loadContent();
+
+    // Load Android files if android directory exists
+    if (this.androidProjectPath) {
+      await this.loadAndroidFilesContent();
+    }
   }
 
   findPreferredLockFile() {
@@ -346,12 +497,17 @@ export class ReactNativeProject
     // Run React Native checks first because wrapper frameworks must be validated before native checks
     await runChecksForReactNative(group);
     await super.runChecks(group);
+
+    // Run Android checks if android directory exists
+    if (this.androidProjectPath) {
+      await this.runAndroidChecks(group);
+    }
   }
 }
 
 export class FlutterProject
-  extends iOSProjectBase(Object)
-  implements MobileProject, iOSProject
+  extends iOSProjectBase(AndroidProjectBase(Object))
+  implements MobileProject, iOSProject, AndroidProject
 {
   public readonly framework: string = 'Flutter';
   public readonly documentation: Links.Documentation =
@@ -359,6 +515,7 @@ export class FlutterProject
 
   public readonly pubspecYamlFile: File;
   public readonly pubspecLockFile: File;
+  public isWrapperFramework: boolean = true;
 
   constructor(projectPath: string) {
     super();
@@ -366,6 +523,14 @@ export class FlutterProject
     this.iOSProjectPath = path.join(projectPath, 'ios');
 
     this.initIOSProject();
+
+    // Check if android directory exists
+    const androidPath = path.join(projectPath, 'android');
+    if (doesExists(androidPath)) {
+      this.androidProjectPath = androidPath;
+      this.initAndroidProject();
+    }
+
     this.pubspecYamlFile = new File(projectPath, 'pubspec.yaml');
     this.pubspecLockFile = new File(projectPath, 'pubspec.lock');
   }
@@ -378,10 +543,20 @@ export class FlutterProject
     this.podfile.loadContent();
     this.podfileLock.loadContent();
     this.packageResolved.loadContent();
+
+    // Load Android files if android directory exists
+    if (this.androidProjectPath) {
+      await this.loadAndroidFilesContent();
+    }
   }
 
   async runChecks(group: CheckGroup): Promise<void> {
     // When added, run Flutter checks first because wrapper frameworks must be validated before native checks
     await super.runChecks(group);
+
+    // Run Android checks if android directory exists
+    if (this.androidProjectPath) {
+      await this.runAndroidChecks(group);
+    }
   }
 }

--- a/src/doctor/core/projects.ts
+++ b/src/doctor/core/projects.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { runChecksForIOS, runChecksForReactNative } from '../checks';
+import {
+  runChecksForAndroid,
+  runChecksForIOS,
+  runChecksForReactNative,
+} from '../checks';
 import { Links } from '../constants';
 import { CheckGroup } from '../types';
 import { createFilePattern } from '../utils';
@@ -367,8 +371,7 @@ const AndroidProjectBase = <TBase extends Constructor>(Base: TBase) =>
     }
 
     async runAndroidChecks(group: CheckGroup): Promise<void> {
-      const { runChecks } = await import('../checks/android.js');
-      await runChecks(group);
+      await runChecksForAndroid(group);
     }
   };
 

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  AndroidNativeProject,
   Context,
   FlutterProject,
   MobileProject,
@@ -87,6 +88,46 @@ function identifyProject(projectDirectory: string): MobileProject | undefined {
   // Check for Flutter (looking for a pubspec.yaml file)
   if (fs.existsSync(path.join(projectDirectory, 'pubspec.yaml'))) {
     return new FlutterProject(projectDirectory);
+  }
+
+  // Check for Android Native
+  // Two possible structures:
+  // 1. Standard multi-module: app/build.gradle
+  // 2. Single-module (samples): build.gradle at root with com.android.application plugin
+  const androidAppBuildGradle = path.join(
+    projectDirectory,
+    'app',
+    'build.gradle'
+  );
+  const androidAppBuildGradleKts = path.join(
+    projectDirectory,
+    'app',
+    'build.gradle.kts'
+  );
+
+  if (
+    fs.existsSync(androidAppBuildGradle) ||
+    fs.existsSync(androidAppBuildGradleKts)
+  ) {
+    return new AndroidNativeProject(projectDirectory);
+  }
+
+  // Check for single-module Android project (build.gradle at root)
+  const rootBuildGradle = path.join(projectDirectory, 'build.gradle');
+  const rootBuildGradleKts = path.join(projectDirectory, 'build.gradle.kts');
+
+  if (fs.existsSync(rootBuildGradle)) {
+    const content = fs.readFileSync(rootBuildGradle, 'utf8');
+    if (content.includes('com.android.application')) {
+      return new AndroidNativeProject(projectDirectory);
+    }
+  }
+
+  if (fs.existsSync(rootBuildGradleKts)) {
+    const content = fs.readFileSync(rootBuildGradleKts, 'utf8');
+    if (content.includes('com.android.application')) {
+      return new AndroidNativeProject(projectDirectory);
+    }
   }
 
   // Check for iOS Native (looking for a .xcodeproj directory)

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -106,9 +106,15 @@ function identifyProject(projectDirectory: string): MobileProject | undefined {
     'build.gradle.kts'
   );
 
+  const hasAndroidAppPlugin = (filePath: string): boolean => {
+    if (!fs.existsSync(filePath)) return false;
+    const content = fs.readFileSync(filePath, 'utf8');
+    return content.includes('com.android.application');
+  };
+
   if (
-    fs.existsSync(androidAppBuildGradle) ||
-    fs.existsSync(androidAppBuildGradleKts)
+    hasAndroidAppPlugin(androidAppBuildGradle) ||
+    hasAndroidAppPlugin(androidAppBuildGradleKts)
   ) {
     return new AndroidNativeProject(projectDirectory);
   }
@@ -117,18 +123,11 @@ function identifyProject(projectDirectory: string): MobileProject | undefined {
   const rootBuildGradle = path.join(projectDirectory, 'build.gradle');
   const rootBuildGradleKts = path.join(projectDirectory, 'build.gradle.kts');
 
-  if (fs.existsSync(rootBuildGradle)) {
-    const content = fs.readFileSync(rootBuildGradle, 'utf8');
-    if (content.includes('com.android.application')) {
-      return new AndroidNativeProject(projectDirectory);
-    }
-  }
-
-  if (fs.existsSync(rootBuildGradleKts)) {
-    const content = fs.readFileSync(rootBuildGradleKts, 'utf8');
-    if (content.includes('com.android.application')) {
-      return new AndroidNativeProject(projectDirectory);
-    }
+  if (
+    hasAndroidAppPlugin(rootBuildGradle) ||
+    hasAndroidAppPlugin(rootBuildGradleKts)
+  ) {
+    return new AndroidNativeProject(projectDirectory);
   }
 
   // Check for iOS Native (looking for a .xcodeproj directory)

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -227,8 +227,8 @@ export function compareSemanticVersions(
   if (version1 === undefined) return -1;
   if (version2 === undefined) return 1;
 
-  const v1Parts = version1.split('.').map(Number);
-  const v2Parts = version2.split('.').map(Number);
+  const v1Parts = version1.split('-')[0].split('.').map(Number);
+  const v2Parts = version2.split('-')[0].split('.').map(Number);
 
   // Compare each part of the version numbers
   for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -93,7 +93,7 @@ export function extractVersionFromBuildGradle(
   // Handles both single and double quotes, with or without parentheses
   const escapedGroup = packageGroup.replace(/\./g, '\\.');
   const pattern = new RegExp(
-    `['"]${escapedGroup}:${moduleName}:([\\d.]+)['"]`,
+    `['"]${escapedGroup}:${moduleName}:([\\d.]+(?:-[\\w.]+)?)['"]`,
     'g'
   );
   const match = pattern.exec(content);

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -91,8 +91,9 @@ export function extractVersionFromBuildGradle(
 ): string | undefined {
   // Pattern matches: packageGroup:moduleName:version
   // Handles both single and double quotes, with or without parentheses
+  const escapedGroup = packageGroup.replace(/\./g, '\\.');
   const pattern = new RegExp(
-    `['"]${packageGroup}:${moduleName}:([\\d.]+)['"]`,
+    `['"]${escapedGroup}:${moduleName}:([\\d.]+)['"]`,
     'g'
   );
   const match = pattern.exec(content);

--- a/src/doctor/utils/version.ts
+++ b/src/doctor/utils/version.ts
@@ -72,6 +72,34 @@ export function extractVersionFromPackageJson(
 }
 
 /**
+ * Extracts version from build.gradle for a specific Android dependency.
+ * Handles both Groovy DSL and Kotlin DSL syntax.
+ *
+ * @example
+ * // Groovy DSL: implementation 'io.customer.android:datapipelines:3.1.0'
+ * // Kotlin DSL: implementation("io.customer.android:datapipelines:3.1.0")
+ *
+ * @param content Content of the build.gradle or build.gradle.kts file
+ * @param packageGroup Maven group ID (e.g., 'io.customer.android')
+ * @param moduleName Module name (e.g., 'datapipelines')
+ * @returns Version string if found, undefined otherwise
+ */
+export function extractVersionFromBuildGradle(
+  content: string,
+  packageGroup: string,
+  moduleName: string
+): string | undefined {
+  // Pattern matches: packageGroup:moduleName:version
+  // Handles both single and double quotes, with or without parentheses
+  const pattern = new RegExp(
+    `['"]${packageGroup}:${moduleName}:([\\d.]+)['"]`,
+    'g'
+  );
+  const match = pattern.exec(content);
+  return match ? match[1] : undefined;
+}
+
+/**
  * Extracts version, branch, or revision from Package.resolved (SPM) for a given package identity
  * Package.resolved format (v2/v3):
  * {


### PR DESCRIPTION
part of: [MBL-1594](https://linear.app/customerio/issue/MBL-1594/add-improvements-to-npm-doctor-diagnostics)

### Summary

Adds Android project detection and doctor checks for native Android, React Native, and Flutter projects. Validates `minSdkVersion`, `targetSdkVersion`, SDK initialization, Google Services config, `FirebaseMessagingService`, conflicting libraries, and SDK dependency versions against the latest published release. Uses a mixin pattern (`AndroidProjectBase`) consistent with the existing `iOSProjectBase` architecture.

### Changes

- **`checks/android.ts`:** New check module with all Android-specific validations
- **`core/projects.ts`:** `AndroidProjectBase` mixin and `AndroidNativeProject` class; `ReactNativeProject` and `FlutterProject` now extend both iOS and Android mixins
- **`index.ts`:** Project detection for standalone Android projects (multi-module and single-module)
- **`constants/`:** Android SDK constants, conflict list, and documentation links
- **`utils/version.ts`:** `extractVersionFromBuildGradle()` for Groovy and Kotlin DSL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Android detection and check execution paths and changes shared version parsing/comparison, which could affect doctor behavior across projects if parsing logic misses edge cases.
> 
> **Overview**
> Adds **Android support** to the `doctor` tool, including native Android project detection and a new Android check suite for SDK versions, initialization, push setup (Google services/Firebase), conflicting push libraries, and Customer.io Android dependency version validation.
> 
> Extends project modeling to include Android files via an `AndroidProjectBase` mixin and an `AndroidNativeProject`, and updates React Native/Flutter projects to optionally load and run Android checks when an `android/` directory exists.
> 
> Introduces Android-specific constants/links and Gradle conflict patterns, and adds `extractVersionFromBuildGradle()` plus prerelease-tolerant `compareSemanticVersions()` to support Gradle dependency analysis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d203c4fc4087ce352826f0a04b5850b2279edf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->